### PR TITLE
Fix link to Contributing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ and secrets management in general.
 
 [1. Leak Mitigation Checklist](Leak%20Mitigation%20Checklist.md)
 
-[2. How to Contribute](Contributing.md)
+[2. How to Contribute](CONTRIBUTING.md)


### PR DESCRIPTION
The link to the Contributing page in the README was 404ing.
This is because URLs are case sensitive and the file is all uppercase.

Fixes #1